### PR TITLE
Force abapcleaner.gui plugin activation when checking handler enablement

### DIFF
--- a/com.sap.adt.abapcleaner.gui/META-INF/MANIFEST.MF
+++ b/com.sap.adt.abapcleaner.gui/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Eclipse-ExtensibleAPI: true
 Require-Bundle: com.sap.adt.abapcleaner;bundle-version="0.0.0",
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
+ org.eclipse.core.expressions,
  org.eclipse.swt,
  org.eclipse.jface,
  org.eclipse.jface.text,

--- a/com.sap.adt.abapcleaner.gui/plugin.xml
+++ b/com.sap.adt.abapcleaner.gui/plugin.xml
@@ -23,6 +23,16 @@
       </command>
    </extension>
    <extension
+         point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            class="com.sap.adt.abapcleaner.gui.eclipse.DummyForcePluginActivationPropertyTester"
+            id="com.sap.adt.abapcleaner.gui.dummyPropertyTester"
+            namespace="com.sap.adt.abapcleaner.gui"
+            properties="forcePluginActivation"
+            type="java.lang.Object">
+      </propertyTester>
+   </extension>
+   <extension
          point="org.eclipse.ui.menus">
       <menuContribution
             allPopups="false"
@@ -35,6 +45,10 @@
                   checkEnabled="false">
                <with
                      variable="activePart">
+                  <test
+                        forcePluginActivation="true"
+                        property="com.sap.adt.abapcleaner.gui.forcePluginActivation">
+                  </test>
                   <test
                         args="com.sap.adt.abapcleaner.cleanup.automatic"
                         forcePluginActivation="true"
@@ -53,6 +67,10 @@
                <with
                      variable="activePart">
                   <test
+                        forcePluginActivation="true"
+                        property="com.sap.adt.abapcleaner.gui.forcePluginActivation">
+                  </test>
+                  <test
                         args="com.sap.adt.abapcleaner.cleanup.interactive"
                         forcePluginActivation="true"
                         property="com.sap.adt.tools.abapsource.ui.editormenu.shouldShowContextMenu"
@@ -69,6 +87,10 @@
                   checkEnabled="false">
                <with
                      variable="activePart">
+                  <test
+                        forcePluginActivation="true"
+                        property="com.sap.adt.abapcleaner.gui.forcePluginActivation">
+                  </test>
                   <test
                         args="com.sap.adt.abapcleaner.cleanup.readonly"
                         forcePluginActivation="true"

--- a/com.sap.adt.abapcleaner.gui/src/com/sap/adt/abapcleaner/gui/eclipse/DummyForcePluginActivationPropertyTester.java
+++ b/com.sap.adt.abapcleaner.gui/src/com/sap/adt/abapcleaner/gui/eclipse/DummyForcePluginActivationPropertyTester.java
@@ -1,0 +1,19 @@
+package com.sap.adt.abapcleaner.gui.eclipse;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.expressions.PropertyTester;
+
+/**
+ * Always returns <code>true</code>. Used in plugin.xml in combination with
+ * <code>forcePluginActivation="true"</code> to make sure that the plugin is
+ * activated and handlers' {@link AbstractHandler#setEnabled(Object)} is
+ * considered even very early after ADT startup (Eclipse is optimistic with
+ * regards to Handler enablement until the plugin is activated).
+ */
+public class DummyForcePluginActivationPropertyTester extends PropertyTester {
+
+	@Override
+	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+		return true;
+	}
+}


### PR DESCRIPTION
Eclipse is optimistic with regards to enablement of a Handler, i.e. it will not activate a plugin to call AbstractHandler#setEnabled().

This can lead to situations where the ABAP cleaner actions in the menus are enabled, even if they are not applicable to the object type in the editor, because the com.sap.adt.abapcleaner.gui plugin is not yet fully loaded.

This change adds a dummy property tester to enforce the plugin activation.