### PR TITLE
Update in-solidarity.yml

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,5 +1,3 @@
 rules:
   master:
     level: off
-  masterdata:
-    level: off


### PR DESCRIPTION
If we provide our own config

`org/repo/.github/in-solidarity.yml`

then the one of the organization's .github repo

`org/.github/.github/in-solidarity.yml`

is not considered anymore.