### PR TITLE
ci: publish unit test results also on pull requests coming from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,20 @@ jobs:
           maven-version: 3.9.6
       - name: Build with Maven
         run: mvn --batch-mode --fail-at-end clean verify
-      - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          files: ${{ github.workspace }}/**/target/surefire-reports/*.xml
+          name: Test Results
+          if-no-files-found: warn
+          path: |
+            ${{ github.workspace }}/**/target/surefire-reports/*.xml
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,43 @@
+name: Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+
+      # needed unless run with comment_mode: off
+      pull-requests: write
+
+      # only needed for private repository
+      contents: read
+
+      # only needed for private repository
+      issues: read
+
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          path: artifacts
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
Make publishing of test results also work when pull requests is coming from a forked repository.

Based on the recommended setup [1].

[1] https://github.com/EnricoMi/publish-unit-test-result-action/blob/v2.15.1/README.md#support-fork-repositories-and-dependabot-branches