### PR TITLE
Releng updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: |
-            11
             17
+            21
+          mvn-toolchain-id: |
+            JavaSE-17
+            JavaSE-21
           distribution: 'temurin'
           cache: maven
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.6
+          maven-version: 3.9.8
       - name: Build with Maven
         run: mvn --batch-mode --fail-at-end clean verify
       - name: Upload Test Results

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn --batch-mode clean package -DskipTests
@@ -36,7 +36,7 @@ jobs:
           body: | 
             We recommend using the ABAP cleaner **plug-in for ADT** (see [installation instructions](../../blob/main/README.md)), which cleans up your code directly from within ADT, and checks for updates automatically. If you nevertheless prefer to use the **stand-alone version** of ABAP cleaner (e.g. in order to use it with SAP GUI or from the command line), please 
 
-            * make sure Java 17 or 11 (e.g. [SapMachine](https://sap.github.io/SapMachine/) or [Adoptium Temurin](https://adoptium.net/)) is installed on your system, and in the app 'Edit the system environment variables' (Windows), System variable 'Path' contains the path to the java.exe (e.g. C:\Program Files\SapMachine\JDK\17\bin)
+            * make sure Java 21 or 17 (e.g. [SapMachine](https://sap.github.io/SapMachine/) or [Adoptium Temurin](https://adoptium.net/)) is installed on your system, and in the app 'Edit the system environment variables' (Windows), System variable 'Path' contains the path to the java.exe (e.g. C:\Program Files\SapMachine\JDK\17\bin)
             * expand "Assets" below and download the archive for your operating system
             * extract the archive
             * on macOS:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To install and use the **ABAP cleaner plug-in for ABAP Development Tools** (ADT)
    (shortcuts *Ctrl + 4* or *Ctrl + Shift + 4*), see [usage](docs/usage.md).
 
 The **stand-alone version of ABAP cleaner** (for Windows, macOS or Linux) 
-requires Java 17 or 11 (e.g. [SapMachine](https://sap.github.io/SapMachine/) or [Adoptium Temurin](https://adoptium.net/)). 
+requires Java 21 or 17 (e.g. [SapMachine](https://sap.github.io/SapMachine/) or [Adoptium Temurin](https://adoptium.net/)). 
 To install the stand-alone version, please download and extract the latest [Release](../../releases) 
 and follow the installation instructions given there.
 

--- a/com.sap.adt.abapcleaner.app/abapcleaner.product
+++ b/com.sap.adt.abapcleaner.app/abapcleaner.product
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="ABAP cleaner" uid="com.sap.adt.abapcleaner.app" application="com.sap.adt.abapcleaner.standalone.app" version="1.16.3.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="ABAP cleaner" uid="com.sap.adt.abapcleaner.app" application="com.sap.adt.abapcleaner.standalone.app" version="1.16.3.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
 
    <launcherArgs>
+      <vmArgs>-Dosgi.requiredJavaVersion=17
+      </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
    </launcherArgs>

--- a/com.sap.adt.abapcleaner.gui/.classpath
+++ b/com.sap.adt.abapcleaner.gui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/com.sap.adt.abapcleaner.gui/.settings/org.eclipse.jdt.core.prefs
+++ b/com.sap.adt.abapcleaner.gui/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -12,4 +12,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/com.sap.adt.abapcleaner.gui/META-INF/MANIFEST.MF
+++ b/com.sap.adt.abapcleaner.gui/META-INF/MANIFEST.MF
@@ -5,10 +5,10 @@ Bundle-SymbolicName: com.sap.adt.abapcleaner.gui;singleton:=true
 Bundle-Version: 1.16.3.qualifier
 Bundle-Vendor: %Provider-Name
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Eclipse-ExtensibleAPI: true
-Require-Bundle: com.sap.adt.abapcleaner;bundle-version="0.0.0",
+Require-Bundle: com.sap.adt.abapcleaner;bundle-version="1.16.3",
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.core.expressions,
@@ -19,10 +19,10 @@ Require-Bundle: com.sap.adt.abapcleaner;bundle-version="0.0.0",
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench,
  org.eclipse.ui.workbench.texteditor,
- com.sap.adt.util.ui,
- com.sap.adt.tools.core.ui,
- com.sap.adt.tools.abapsource,
- com.sap.adt.tools.abapsource.ui
+ com.sap.adt.util.ui;bundle-version="3.38.2",
+ com.sap.adt.tools.core.ui;bundle-version="3.38.2",
+ com.sap.adt.tools.abapsource;bundle-version="3.38.2",
+ com.sap.adt.tools.abapsource.ui;bundle-version="3.38.2"
 Automatic-Module-Name: com.sap.adt.abapcleaner.gui
 Import-Package: com.sap.adt.tools.abapsource.parser.padfileresolver.internal,
  com.sap.rnd.rndrt

--- a/com.sap.adt.abapcleaner/.classpath
+++ b/com.sap.adt.abapcleaner/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/com.sap.adt.abapcleaner/.settings/org.eclipse.jdt.core.prefs
+++ b/com.sap.adt.abapcleaner/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -12,4 +12,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/com.sap.adt.abapcleaner/META-INF/MANIFEST.MF
+++ b/com.sap.adt.abapcleaner/META-INF/MANIFEST.MF
@@ -5,11 +5,11 @@ Bundle-SymbolicName: com.sap.adt.abapcleaner;singleton:=true
 Bundle-Version: 1.16.3.qualifier
 Bundle-Vendor: %Provider-Name
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Eclipse-ExtensibleAPI: true
-Require-Bundle: com.sap.rnd.rndrt;bundle-version="1.92.0",
- com.sap.adt.tools.abapsource.parser;bundle-version="3.16.1",
+Require-Bundle: com.sap.rnd.rndrt;bundle-version="1.108.0",
+ com.sap.adt.tools.abapsource.parser;bundle-version="3.38.2",
  org.eclipse.jface.text,
  org.eclipse.core.runtime
 Export-Package: com.sap.adt.abapcleaner.base,

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,10 @@
     <module>test</module>
   </modules>
   <properties>
-    <tycho-version>3.0.1</tycho-version>
+    <tycho-version>4.0.8</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <executionEnvironment>JavaSE-11</executionEnvironment>
+    <executionEnvironment>JavaSE-17</executionEnvironment>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
   <build>
     <plugins>
@@ -72,6 +73,7 @@
         <version>${tycho-version}</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
+          <useJDK>BREE</useJDK> <!-- Run tests with BREE execution environment (minimum JDK supported), requires matching entry in ~/.m2/toolchains.xml with id == JavaSE-XX" -->
           <dependencies>
             <!-- avoid CNFE in Surefire when looking for JUnitPlatformProvider -->
             <dependency>
@@ -86,12 +88,12 @@
   <repositories>
     <repository>
       <id>eclipse</id>
-      <url>https://download.eclipse.org/releases/2022-12</url>
+      <url>https://download.eclipse.org/releases/2023-06</url>
       <layout>p2</layout>
     </repository>
     <repository>
       <id>adt</id>
-      <url>https://tools.hana.ondemand.com/2022-12</url>
+      <url>https://tools.hana.ondemand.com/2023-06</url>
       <layout>p2</layout>
     </repository>
   </repositories>

--- a/test/com.sap.adt.abapcleaner.test/.classpath
+++ b/test/com.sap.adt.abapcleaner.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/test/com.sap.adt.abapcleaner.test/.settings/org.eclipse.jdt.core.prefs
+++ b/test/com.sap.adt.abapcleaner.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -12,4 +12,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/test/com.sap.adt.abapcleaner.test/META-INF/MANIFEST.MF
+++ b/test/com.sap.adt.abapcleaner.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: com.sap.adt.abapcleaner.test;singleton:=true
 Bundle-Version: 1.16.3.qualifier
 Bundle-Vendor: abap-dev
 Fragment-Host: com.sap.adt.abapcleaner
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit.jupiter.api;version="5.7.1"
 Automatic-Module-Name: com.sap.adt.abapcleaner.test


### PR DESCRIPTION
* Bump minimum Java version to Java 17

* Build against and require ADT 3.38 / Eclipse 2023-06 (oldest version requiring Java 17).

* Use latest Maven version.

* Build using latest Tycho 4.0.8.

* Build using Java 21.

* Run surefire tests with Java 17 based on maven toolchain.

* Add explicit '-Dosgi.requiredJavaVersion=17' VM argument to stand- alone product.