### PR TITLE
ci: Migrate from Temurin 17,21 to SapMachine 17,21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           mvn-toolchain-id: |
             JavaSE-17
             JavaSE-21
-          distribution: 'temurin'
+          distribution: 'sapmachine'
           cache: maven
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,15 +12,15 @@ permissions:
 jobs:
   # Single deploy job since we're just deploying
   release:
-    runs-on: ubuntu-latest, self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'sapmachine'
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   # Single deploy job since we're just deploying
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest, self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Hi Colleagues,

[SapMachine](https://sapmachine.io/) is now available with
actions/setup-java@v4
Created a PR to migrate from Temurin to SapMachine

Regards Christian@SapMachine Team

PS: there are newer versions of some actions you consume. eg from 
actions/checkout@v3
is already version 4 available