### PR TITLE
Include JRE in stand-alone app

### DIFF
--- a/com.sap.adt.abapcleaner.app/abapcleaner.product
+++ b/com.sap.adt.abapcleaner.app/abapcleaner.product
@@ -29,6 +29,7 @@
    </plugins>
 
    <features>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped"/>
       <feature id="com.sap.adt.abapcleaner.feature"/>
    </features>
 

--- a/com.sap.adt.abapcleaner.app/pom.xml
+++ b/com.sap.adt.abapcleaner.app/pom.xml
@@ -18,11 +18,22 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <executionEnvironment>none</executionEnvironment>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-director-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>materialize-products</id>
+            <!-- Bind to prepare-package (instead of the default package phase) so that the
+                 shorten-win32-jre-path antrun step below can run before archive-products. -->
+            <phase>prepare-package</phase>
             <goals>
               <goal>materialize-products</goal>
             </goals>
@@ -44,7 +55,54 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           </products>
         </configuration>
       </plugin>
+
+      <!-- On Windows, the JustJ JRE is materialized under a deeply nested, versioned
+           plugins/... folder. Combined with the JRE's own internal paths this can exceed
+           the 260-char MAX_PATH limit and make the launcher fail. To avoid that, move the
+           JRE up to abapcleaner/jre and point abap-cleaner.ini at the shorter path.
+           This runs after materialize-products (prepare-package) and before
+           archive-products (package), so the fix is included in the win32 product zip. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shorten-win32-jre-path</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <property name="win32ProductDir"
+                          value="${project.build.directory}/products/com.sap.adt.abapcleaner.app/win32/win32/x86_64/abapcleaner"/>
+                <!-- Resolve the versioned JustJ JRE folder name (changes per JRE release). -->
+                <pathconvert property="win32JreSrcDir" setonempty="false">
+                  <dirset dir="${win32ProductDir}/plugins">
+                    <include name="org.eclipse.justj.openjdk.*.win32.*/jre"/>
+                  </dirset>
+                </pathconvert>
+                <!-- Move plugins/org.eclipse.justj.../jre to abapcleaner/jre. -->
+                <move file="${win32JreSrcDir}" tofile="${win32ProductDir}/jre"/>
+                <!-- Rewrite the -vm path in abap-cleaner.ini to the shortened location. -->
+                <replaceregexp file="${win32ProductDir}/abap-cleaner.ini"
+                               match="plugins/org\.eclipse\.justj[^/\r\n]*/jre/bin"
+                               replace="jre/bin"
+                               flags="g"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>justj</id>
+      <url>https://download.eclipse.org/justj/jres/21/updates/release/21.0.10</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.6.1</version>

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,30 @@
   "extends": [
     "config:recommended"
   ],
+  "customDatasources": {
+    "eclipse-p2-page": {
+      "format": "html"
+    }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/|\\.)pom\\.xml$/"
+      ],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        "<repositories>(.|\\s)*?</repositories>",
+        "<repository>(.|\\s)*?</repository>",
+        "<url>https://download.eclipse.org/justj/jres/(?<currentValueMajor>.*)/updates/release/(?<currentValue>.*)</url>"
+      ],
+      "depNameTemplate": "justj",
+      "registryUrlTemplate": "https://download.eclipse.org/justj/jres/{{ currentValueMajor }}/updates/release",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.eclipse-p2-page",
+      "extractVersionTemplate": ".*/(?<version>\\d+\\.\\d+\\.\\d+)/.*$"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "tycho",


### PR DESCRIPTION
Currently, the stand-alone apps depends on a matching JVM in the PATH or a manual configuration via '-vm' parameter in abap-cleaner.ini.

Bundling a JVM in the app would makes it self-contained and independent from the environment.

We let Tycho bundle a JustJ [1] Minimal Stripped JRE.

Resolves #471.

[1] https://eclipse.dev/justj/