### PR TITLE
static.yml: Use gh cli to download release asset

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,13 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - id: download-release-asset
-        name: Download release asset
-        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
-        with:
-          version: tags/${{ inputs.release-tag }}
-          file: com.sap.adt.abapcleaner.updatesite.zip
-          target: release.zip
+      - name: Download release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download ${{ inputs.release-tag }} -p com.sap.adt.abapcleaner.updatesite.zip -O release.zip
       - name: Assemble content
         run: unzip release.zip -d _site/updatesite/
       - name: Setup Pages


### PR DESCRIPTION
Replace apparently abandoned dsaltares/fetch-gh-release-asset with gh cli.